### PR TITLE
zwrite: Assume UTF-8 rather than ISO-8859-1 in an ASCII locale

### DIFF
--- a/lib/charset.c
+++ b/lib/charset.c
@@ -60,7 +60,7 @@ ZGetCharset(char *charset)
     if (!strcmp(charset, "NONE") || !strcmp(charset, "UNKNOWN"))
 	retval = ZCHARSET_UNKNOWN;
     else if (!strcmp(charset, "ANSI_X3.4-1968"))
-	retval = ZCHARSET_ISO_8859_1; /* A hack. */
+	retval = ZCHARSET_UTF_8; /* A hack. */
     else if (!strcmp(charset, "ISO-8859-1"))
 	retval = ZCHARSET_ISO_8859_1;
     else if (!strcmp(charset, "UTF-8"))


### PR DESCRIPTION
It turns out that lots of scripts still run `zwrite` without setting any locale environment variables.  The charset of the default C locale is ANSI_X3.4-1968 (ASCII), so we were sending `z_charset = ZCHARSET_ISO_8859_1`.  But UTF-8 is much more common these days, so this results in a lot of mislabeled zephyrs.

Other clients just ignore `z_charset` (Roost made a good-faith effort to respect it, and gave up after finding that it really has no correlation with the actual charset); but it still caused incorrect display in `zwgc`.

Since UTF-8 is just as good a superset of ASCII as ISO-8859-1 is, we should just assume UTF-8 by default in this case.

(We still assume ISO-8859-1 if the locale explicitly specifies that, such as `en_US`.  Almost nobody uses such locales anymore.)
