### PR TITLE
Enable reproducible building by removing irrelevant data from version string

### DIFF
--- a/new_vers.sh
+++ b/new_vers.sh
@@ -2,10 +2,7 @@
 #
 top_srcdir=${1:-`pwd`}
 
-u=${USER-the_zephyr_builder}
-h=`hostname`
-t=`date`
 v=`sh ${top_srcdir}/get_vers.sh ${top_srcdir}`
 
 umask 002
-/bin/echo "#define ZEPHYR_VERSION_STRING \"${v} (${t}) ${u}@${h}\"" > h/zephyr_version.h
+/bin/echo "#define ZEPHYR_VERSION_STRING \"${v}\"" > h/zephyr_version.h


### PR DESCRIPTION
Username, hostname and date are depending on the build machine and not really interesting in the version information.
To allow building zephyr reproducibly this should be dropped from being embedded in the binary.