### PR TITLE
Enable seccomp for zhm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,7 +264,27 @@ if test "x$with_ares" != "xno"; then
 			     AC_MSG_ERROR(libcares not found)))
 fi
 AC_SUBST(ARES_LIBS)
-		    
+
+AC_ARG_WITH(seccomp,
+	[AS_HELP_STRING([--without-seccomp], [Disable seccomp])
+AS_HELP_STRING([--with-seccomp=PREFIX], [Specify location of libseccomp])],
+	[seccomp="$withval"], [seccomp=maybe])
+AS_IF([test "x$seccomp" != "xno"], [
+	AS_IF([test "x$seccomp" != "xyes" && test "x$seccomp" != "xmaybe"], [
+		CPPFLAGS="$CPPFLAGS -I$seccomp/include"
+		LDFLAGS="$LDFLAGS -I$seccomp/lib"
+	])
+	AC_CHECK_LIB(seccomp, seccomp_init, [
+		SECCOMP_LIBS="-lseccomp"
+		AC_DEFINE(HAVE_SECCOMP, 1,
+			[Define to compile with libseccomp support.])
+	], [
+		AS_IF([test "x$seccomp" != "xmaybe"],
+			AC_MSG_ERROR([libseccomp not found]))
+	])
+])
+AC_SUBST(SECCOMP_LIBS)
+
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_VPRINTF
 AC_FUNC_GETPGRP

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,8 @@ Build-Depends: debhelper (>= 5), libc-ares-dev, libkrb5-dev (>= 1.2.2-4),
                comerr-dev, ss-dev, libreadline-dev | libreadline5-dev,
                libx11-dev, libxt-dev, x11proto-core-dev, libncurses5-dev,
 	       bison, libhesiod-dev, autotools-dev, python (>= 2.5), python-central,
-               autoconf, libtool, automake, git-core | git, devscripts
+               autoconf, libtool, automake, git-core | git, devscripts,
+               libseccomp-dev
 Build-Conflicts: autoconf2.13
 Standards-Version: 3.9.2.0
 Homepage: http://zephyr.1ts.org/

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,8 @@ PACKAGES:=-plibzephyr4 -pzephyr-clients -pzephyr-server -plibzephyr-dev -plibzep
 export DH_OPTIONS
 CONFIGURE_ROOT=--prefix=/usr --mandir=\$${prefix}/share/man \
 	--infodir=\$${prefix}/share/info --sysconfdir=/etc --datadir=/etc \
-	--with-cares=/usr --with-hesiod=/usr --enable-cmu-zwgcplus
+	--with-cares=/usr --with-hesiod=/usr --with-seccomp=/usr \
+	--enable-cmu-zwgcplus
 CONFIGURE_krb5=--with-krb5=/usr
 CONFIGURE_krb45=--with-krb4=/usr --with-krb5=/usr
 CONFIGURE_krb=--with-krb4=/usr

--- a/zhm/Makefile.in
+++ b/zhm/Makefile.in
@@ -33,13 +33,14 @@ CFLAGS=@CFLAGS@
 ALL_CFLAGS=${CFLAGS} -I${top_srcdir}/h -I${BUILDTOP}/h ${CPPFLAGS}
 LDFLAGS=@LDFLAGS@
 HESIOD_LIBS=@HESIOD_LIBS@
+SECCOMP_LIBS=@SECCOMP_LIBS@
 
 OBJS=	timer.o queue.o zhm.o zhm_client.o zhm_server.o
 
 all: zhm zhm.8
 
 zhm: ${OBJS} ${LIBZEPHYR}
-	${LIBTOOL} --mode=link ${CC} ${LDFLAGS} -o $@ ${OBJS} ${LIBZEPHYR} ${HESIOD_LIBS} -lcom_err
+	${LIBTOOL} --mode=link ${CC} ${LDFLAGS} -o $@ ${OBJS} ${LIBZEPHYR} ${HESIOD_LIBS} -lcom_err ${SECCOMP_LIBS}
 
 zhm.8: ${srcdir}/zhm.8.in Makefile
 	${editman} ${srcdir}/$@.in > $@.tmp


### PR DESCRIPTION
Currently, zhm runs as root and handles network traffic; any sandboxing we can get at all is a positive development. This PR implements a basic seccomp-bpf filter for zhm using [libseccomp](https://github.com/seccomp/libseccomp). The filter still allows a lot of potentially dangerous operations (e.g., [unlink(2)](http://man7.org/linux/man-pages/man2/unlink.2.html)), but it does block stuff like [ptrace(2)](http://man7.org/linux/man-pages/man2/ptrace.2.html), so it’s a definite improvement over nothing at all.

The filter is based partly on a close reading of the zhm and libhesiod source code and partly on empirical evidence from running zhm under [strace(1)](https://manpages.debian.org/buster/strace/strace.1.en.html). I’ve run zhm with this filter for several days without incident, but some edge cases (e.g., server failover) are still untested.

This PR also enables seccomp in Debian builds, which breaks building on kFreeBSD, but Zephyr didn’t build there anyway to begin with, so I don’t feel too bad about it. In any case, it shouldn’t be too hard to conditionalize the libseccomp-dev dependency on being on Linux; I didn’t do it here because it’s simpler this way.